### PR TITLE
Add statistics

### DIFF
--- a/async_reduce/async_reducer.py
+++ b/async_reduce/async_reducer.py
@@ -60,7 +60,7 @@ class AsyncReducer:
             StatsLevel.DETAILED: ident,
         }[self._stats_level]
         stats = self._stats.setdefault(key, AggregatedStats())
-        stats.consume(float(not created))
+        stats.consume(float(created))
 
     @staticmethod
     def _auto_ident(coro: Coroutine[Any, Any, T_Result]) -> str:

--- a/async_reduce/stats.py
+++ b/async_reduce/stats.py
@@ -1,0 +1,59 @@
+import statistics
+from typing import Sequence
+import math
+
+
+class AggregatedStats:
+    _n = 0
+    _mu = _mu2 = _min = _max = 0.0
+
+    def __init__(self, data: Sequence[float] = None):
+        if data:
+            self._n = len(data)
+            self._mu = statistics.mean(data)
+            self._mu2 = statistics.mean((x ** 2 for x in data))
+            self._min = min(data)
+            self._max = max(data)
+
+    @property
+    def n(self) -> int:
+        return self._n
+
+    @property
+    def min(self) -> float:
+        return self._min
+
+    @property
+    def max(self) -> float:
+        return self._max
+
+    @property
+    def mean(self) -> float:
+        return self._mu
+
+    @property
+    def pvariance(self) -> float:
+        return self._mu2 - self._mu ** 2
+
+    @property
+    def pstd(self) -> float:
+        return math.sqrt(self.pvariance)
+
+    @property
+    def variance(self) -> float:
+        return (self._mu2 - self._mu ** 2) * (self._n / (self._n - 1))
+
+    @property
+    def std(self) -> float:
+        return math.sqrt(self.variance)
+
+    def consume(self, *data: float):
+        if data:
+            k = len(data)
+            sm = sum(data)
+            sm2 = sum((x ** 2 for x in data))
+            self._min = min(self._min, *data)
+            self._max = max(self._max, *data)
+            self._mu = (self._mu * self._n + sm) / (k + self._n)
+            self._mu2 = (self._mu2 * self._n + sm2) / (k + self._n)
+            self._n += k

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,117 @@
+import asyncio
+import statistics
+from copy import copy
+
+import pytest
+from asynctest import CoroutineMock
+
+from async_reduce import AsyncReducer
+from async_reduce.async_reducer import StatsLevel
+from async_reduce.stats import AggregatedStats
+
+
+@pytest.fixture()
+def data_init():
+    return list(range(5))
+
+
+@pytest.fixture()
+def data_consume():
+    return list(range(5, 10))
+
+
+def is_close(a, b, rtol=1e-5, atol=1e-8):
+    return abs(a - b) <= atol + rtol*abs(b)
+
+
+@pytest.mark.parametrize(
+    'prop,ref', [
+        ('n', len),
+        ('std', statistics.stdev),
+        ('min', min),
+        ('max', max),
+        ('mean', statistics.mean),
+        ('pvariance', statistics.pvariance),
+        ('variance', statistics.variance),
+        ('std', statistics.stdev),
+        ('pstd', statistics.pstdev),
+    ]
+)
+def test_stats(
+    data_init, data_consume,
+    prop, ref,
+):
+    stats = AggregatedStats(data_init)
+
+    data = copy(data_init)
+    for datum in data_consume:
+        data.append(datum)
+        stats.consume(datum)
+        assert is_close(getattr(stats, prop), ref(data))
+
+
+async def test_reducer_stats_none():
+    result = object()
+    mock = CoroutineMock(return_value=result)
+    async_reduce = AsyncReducer(stats_level=None)
+
+    count = 10
+    args = (1, 2)
+    kwargs = {'1': 2}
+
+    coros = [
+        async_reduce(mock(*args, **kwargs))
+        for _ in range(count)
+    ]
+
+    await asyncio.wait(coros)
+    assert not async_reduce._stats
+
+
+async def test_reducer_stats_overall():
+    # inspect.getcoroutinelocals does not work for CoroutineMock
+    async def coro(a, b, c):
+        pass
+
+    async_reduce = AsyncReducer(stats_level=StatsLevel.OVERALL)
+
+    count = 10
+    args_kwargs = [
+        ((1, 2), {'c': 2}),
+        ((3, 4), {'c': 6}),
+    ]
+    for args, kwargs in args_kwargs:
+        coros = [
+            async_reduce(coro(*args, **kwargs))
+            for _ in range(count)
+        ]
+        await asyncio.wait(coros)
+
+    assert len(async_reduce._stats) == 1
+    assert async_reduce._stats[None].n == 20
+    assert async_reduce._stats[None].mean == 9/10
+
+
+async def test_reducer_stats_detailed():
+    # inspect.getcoroutinelocals does not work for CoroutineMock
+    async def coro(a, b, c):
+        pass
+
+    async_reduce = AsyncReducer(stats_level=StatsLevel.DETAILED)
+
+    count = 10
+    args_kwargs = [
+        ((1, 2), {'c': 2}),
+        ((3, 4), {'c': 6}),
+    ]
+    for args, kwargs in args_kwargs:
+        coros = [
+            async_reduce(coro(*args, **kwargs))
+            for _ in range(count)
+        ]
+        await asyncio.wait(coros)
+
+    assert len(async_reduce._stats) == 2
+    for stats in async_reduce._stats.values():
+        assert stats.n == 10
+        assert stats.mean == 9 / 10

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -66,6 +66,7 @@ async def test_reducer_stats_none():
 
     await asyncio.wait(coros)
     assert not async_reduce._stats
+    assert not async_reduce._ident_args
 
 
 async def test_reducer_stats_overall():
@@ -88,6 +89,7 @@ async def test_reducer_stats_overall():
         await asyncio.wait(coros)
 
     assert len(async_reduce._stats) == 1
+    assert len(async_reduce._ident_args) == 0
     assert async_reduce._stats[None].n == 20
     assert async_reduce._stats[None].mean == 1/10
 
@@ -112,6 +114,7 @@ async def test_reducer_stats_detailed():
         await asyncio.wait(coros)
 
     assert len(async_reduce._stats) == 2
+    assert len(async_reduce._ident_args) == 2
     for stats in async_reduce._stats.values():
         assert stats.n == 10
         assert stats.mean == 1/10

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -89,7 +89,7 @@ async def test_reducer_stats_overall():
 
     assert len(async_reduce._stats) == 1
     assert async_reduce._stats[None].n == 20
-    assert async_reduce._stats[None].mean == 9/10
+    assert async_reduce._stats[None].mean == 1/10
 
 
 async def test_reducer_stats_detailed():
@@ -114,4 +114,4 @@ async def test_reducer_stats_detailed():
     assert len(async_reduce._stats) == 2
     for stats in async_reduce._stats.values():
         assert stats.n == 10
-        assert stats.mean == 9 / 10
+        assert stats.mean == 1/10


### PR DESCRIPTION
May be helpful to get some execution statistics, e.g., how many coroutines are created on average with respect to the total number of calls. Added:

- `AggregatedStats` class that allows to consume floats sequentially and get mean, average, min, max.
- Support in `AsyncReducer` for no stats, overall stats (across all different `ident` values) and detailed stats (for each separate `ident` value + stores repr of arguments)
